### PR TITLE
Fallback on word matching in autocomplete

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Jest All",
+            "program": "${workspaceFolder}/node_modules/.bin/jest",
+            "args": [
+                "--runInBand"
+            ],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "disableOptimisticBPs": true,
+            "windows": {
+                "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+            }
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Command | Effect
 `npm run build-client ` | Builds the client side code.
 `npm run build-server` | Builds the server side code.
 `npm run build` | Builds the client side code, server side code, and creates required directories.
-`npm run start` | Starts the server (but does not build anything new).
+`npm run start` | Starts the server (but does not build anything new). Site is accessible on the port specified in .env (e.g. http://localhost:5757/)
 `npm run start:client-inc` | Builds client code only and starts the server.
 `npm run start:full` | Builds all code and starts the server.
 `npm run test` | Runs all tests.

--- a/src/common/chat/autocompleter.test.ts
+++ b/src/common/chat/autocompleter.test.ts
@@ -77,6 +77,17 @@ test('Autocompleter will find full token if no prefix matches', () => {
   expect(results).toContain('beautiful cabbages');
 });
 
+test('Autocompleter will prefix match first', () => {
+  const completer = Autocompleter.create();
+  const options = ['diocletian', 'farms', 'cabbages', 'beautiful cabbages'];
+
+  completer.addOptions(options);
+  const results = completer.getOptions('cabbages');
+
+  expect(results.length).toBe(1);
+  expect(results).toContain('cabbages');
+});
+
 function expectArraysMatch(first: string[], second: string[]): void {
   expect(first.sort()).toEqual(second.sort());
 }

--- a/src/common/chat/autocompleter.test.ts
+++ b/src/common/chat/autocompleter.test.ts
@@ -66,6 +66,17 @@ test('Autocompleter returns all subpaths', () => {
   expect(results).toContain('diofarms');
 });
 
+test('Autocompleter will find full token if no prefix matches', () => {
+  const completer = Autocompleter.create();
+  const options = ['diocletian', 'farms', 'beautiful cabbages'];
+
+  completer.addOptions(options);
+  const results = completer.getOptions('cabbages');
+
+  expect(results.length).toBe(1);
+  expect(results).toContain('beautiful cabbages');
+});
+
 function expectArraysMatch(first: string[], second: string[]): void {
   expect(first.sort()).toEqual(second.sort());
 }

--- a/src/common/chat/autocompleter.ts
+++ b/src/common/chat/autocompleter.ts
@@ -24,8 +24,8 @@ export class Autocompleter {
       const char = entry.charAt(i);
       const maybeChild = currentNode.getChild(char);
       currentNode =
-        maybeChild !== undefined ?
-          maybeChild : currentNode.addValueAsNeighbor(char);
+          maybeChild !== undefined ?
+            maybeChild : currentNode.addValueAsNeighbor(char);
     }
 
     const tokens = option.split(' ');
@@ -33,9 +33,8 @@ export class Autocompleter {
       if (!this.tokenMap.has(token)) {
         this.tokenMap.set(token, [option]);
       } else {
-        const curOptions: string[] = checkDefined(this.tokenMap.get(token));
-        curOptions.push(option);
-        this.tokenMap.set(token, curOptions);
+        // Update the array held in the map by reference
+        checkDefined(this.tokenMap.get(token)).push(option);
       }
     });
   }
@@ -50,20 +49,20 @@ export class Autocompleter {
   /** Returns the autocomplete options for the given prefix string. */
   getOptions(input: string): string[] {
     const prefix = input.trim().toLowerCase();
-    let found: boolean = true;
+    let foundPrefixMatch: boolean = true;
     let prefixRoot = this.root;
 
     for (let i = 0; i < prefix.length; i++) {
       const char = prefix.charAt(i);
       const next = prefixRoot.getChild(char);
       if (next === undefined) {
-        found = false;
+        foundPrefixMatch = false;
         break;
       }
       prefixRoot = next;
     }
 
-    if (!found) {
+    if (!foundPrefixMatch) {
       return this.tokenMap.has(input) ?
         checkDefined(this.tokenMap.get(input)) : [];
     }

--- a/src/common/chat/autocompleter.ts
+++ b/src/common/chat/autocompleter.ts
@@ -52,7 +52,7 @@ export class Autocompleter {
     const prefix = input.trim().toLowerCase();
     let found: boolean = true;
     let prefixRoot = this.root;
-    let result: string[] = [];
+
     for (let i = 0; i < prefix.length; i++) {
       const char = prefix.charAt(i);
       const next = prefixRoot.getChild(char);
@@ -63,17 +63,13 @@ export class Autocompleter {
       prefixRoot = next;
     }
 
-    if (found) {
-      const start = prefix.substr(0, prefix.length - 1);
-      result = completeFromNode(prefixRoot).map((suffix) => start + suffix);
-    }
-
-    if (result.length > 0) {
-      return result;
-    } else {
+    if (!found) {
       return this.tokenMap.has(input) ?
         checkDefined(this.tokenMap.get(input)) : [];
     }
+
+    const start = prefix.substr(0, prefix.length - 1);
+    return completeFromNode(prefixRoot).map((suffix) => start + suffix);
   }
 }
 

--- a/src/common/chat/autocompleter.ts
+++ b/src/common/chat/autocompleter.ts
@@ -33,9 +33,9 @@ export class Autocompleter {
       if (!this.tokenMap.has(token)) {
         this.tokenMap.set(token, [option]);
       } else {
-        const existingOptions: string[] = checkDefined(this.tokenMap.get(token));
-        existingOptions.push(option);
-        this.tokenMap.set(token, existingOptions);
+        const curOptions: string[] = checkDefined(this.tokenMap.get(token));
+        curOptions.push(option);
+        this.tokenMap.set(token, curOptions);
       }
     });
   }
@@ -71,7 +71,8 @@ export class Autocompleter {
     if (result.length > 0) {
       return result;
     } else {
-      return this.tokenMap.has(input) ? checkDefined(this.tokenMap.get(input)) : [];
+      return this.tokenMap.has(input) ?
+        checkDefined(this.tokenMap.get(input)) : [];
     }
   }
 }


### PR DESCRIPTION
- Added a launch configuration for vscode so that breakpoints can get hit in tests out of the box
- Added a line to the README with where the site is served
- When a prefix match is not found based on the input, fall back on trying to match an entire word

Should address https://github.com/nkprasad12/dnd/issues/96